### PR TITLE
Added dependency for flow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,7 @@ FROM node:6
 
 MAINTAINER Jean-Charles Sisk <jeancharles@gasbuddy.com>
 
+RUN apt-get update && apt-get install -y libelf1
+
 RUN curl -o- -L https://yarnpkg.com/install.sh | bash && \
   yarn global add node-gyp

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:6
 
 MAINTAINER Jean-Charles Sisk <jeancharles@gasbuddy.com>
 
-RUN apt-get update && apt-get install -y libelf1
+RUN apt-get update && apt-get install -y libelf1 && rm -rf /var/lib/apt/lists/*
 
 RUN curl -o- -L https://yarnpkg.com/install.sh | bash && \
   yarn global add node-gyp


### PR DESCRIPTION
The stock `node:6` image is missing a package that is required for `flow` to run properly
( see https://github.com/facebook/flow/issues/210#issuecomment-243742328 )
For teams that want to begin using flow, the `gasbuddy/node-app:wercker` image will need to be able to run flow in order to pass CI.

This branch adds the [libelf1](https://packages.debian.org/jessie/libelf1) package which is required for flow to run on a debian machine.


To test:
1) Build the image and spin it up:
```
docker build -t flow-test .
docker run -it flow-test sh
```

2) Install flow in the container and try to run it:
```
yarn add flow flow-bin
yarn run flow
```

Without `libelf`, you will see:
`error while loading shared libraries: libelf.so.1`
No good :(

_With_ `libelf`, you should see:
`Could not find a .flowconfig in . or any of its parent directories.` 
This is good