### PR TITLE
Added npm5 to dev DockerFile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,12 @@ FROM mhart/alpine-node:6
 MAINTAINER Jean-Charles Sisk <jeancharles@gasbuddy.com>
 
 RUN apk add --no-cache git && \
-    apk add --no-cache --virtual .npm-deps openssl make gcc g++ python && \
-    apk add --no-cache libcurl curl && \
-    apk add --no-cache --virtual .yarn-deps gnupg tar && \
-    mkdir -p /opt && \
-    curl -sL https://yarnpkg.com/latest.tar.gz | tar xz -C /opt && \
-    mv /opt/dist /opt/yarn && \
-    ln -s /opt/yarn/bin/yarn /usr/local/bin && \
-    apk del .yarn-deps
+    apk add --no-cache --virtual .npm-deps openssl make gcc g++ python
+
+RUN npm init -f > /dev/null && \
+  npm install npm@5 && \
+  rm -rf /usr/lib/node_modules package.json ~/.npm && \
+  mv node_modules /usr/lib
 
 COPY npmrc /root/.npmrc
 


### PR DESCRIPTION
We are still using the dev shell container, so we would like that updated to npm5 as well.  I'm not sure if we want to publish with a different tag.  If we do we may need to update gb-services-runner as well.