### PR TITLE
fix SIGTERM handling when using npm run-scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ WORKDIR /pipeline/source
 
 COPY entrypoint.sh /entrypoint.sh
 
+ENV NO_UPDATE_NOTIFIER 1
+
 ENTRYPOINT ["/entrypoint.sh"]
 
 CMD [ "node-app" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN npm init -f > /dev/null
 WORKDIR /pipeline/source
 
 COPY entrypoint.sh /entrypoint.sh
+COPY fakesh /usr/local/bin/
 
 ENV NO_UPDATE_NOTIFIER 1
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,11 +9,11 @@ if [ "$1" = 'node-app' ]; then
   shift
   # Link in the mounted production.json if it's there - overwriting any existing file
   [ -f /config/production.json ] && ln -sf /config/production.json config/production.json
-  [ "$#" -gt 0 -a "$1" != '--' ] && set -- '--' "$@"
+  [ "$#" -gt 0 ] && [ "$1" != '--' ] && set -- '--' "$@"
   if [ "$#" -gt 0 ]; then
     exec tini -- su-exec node-app /usr/local/bin/npm start "$@"
   else
-    exec tini -- su-exec node-app /usr/local/bin/npm start
+    exec tini -- su-exec node-app /usr/local/bin/npm --script-shell /usr/local/bin/fakesh start
   fi
 fi
 

--- a/fakesh
+++ b/fakesh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+[ "${1:0:1}" = "-" ] && shift
+exec "$@"


### PR DESCRIPTION
npm forwards a couple of signals to the shell is spawns but—in many cases—the shell doesn't go on to forward from there.

`exec`ing allows us to replace the shell with our process, avoiding the signal-suppressing.

... I also hate the npm update check failed message so ... away with you!